### PR TITLE
Operator to set collection offset from object

### DIFF
--- a/release/scripts/startup/bl_operators/object.py
+++ b/release/scripts/startup/bl_operators/object.py
@@ -1015,6 +1015,7 @@ class OBJECT_OT_assign_property_defaults(Operator):
 classes = (
     ClearAllRestrictRender,
     DupliOffsetFromCursor,
+    DupliOffsetFromObject,
     IsolateTypeRender,
     JoinUVs,
     LoadBackgroundImage,

--- a/release/scripts/startup/bl_operators/object.py
+++ b/release/scripts/startup/bl_operators/object.py
@@ -876,6 +876,23 @@ class DupliOffsetFromCursor(Operator):
 
         return {'FINISHED'}
 
+class DupliOffsetFromObject(Operator):
+    """Set offset used for collection instances based on active object position"""
+    bl_idname = "object.instance_offset_from_active_object"
+    bl_label = "Set Offset From Object"
+    bl_options = {'INTERNAL', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return (context.active_object is not None)
+
+    def execute(self, context):
+        scene = context.scene
+        collection = context.collection
+
+        collection.instance_offset = context.active_object.location
+
+        return {'FINISHED'}
 
 class LoadImageAsEmpty:
     bl_options = {'REGISTER', 'UNDO'}

--- a/release/scripts/startup/bl_ui/properties_object.py
+++ b/release/scripts/startup/bl_ui/properties_object.py
@@ -165,6 +165,7 @@ class COLLECTION_MT_context_menu(Menu):
         layout.operator("object.collection_unlink", icon='X')
         layout.operator("object.collection_objects_select")
         layout.operator("object.instance_offset_from_cursor")
+        layout.operator("object.instance_offset_from_active_object")
 
 
 class OBJECT_PT_collections(ObjectButtonsPanel, Panel):


### PR DESCRIPTION
Add an operator to quickly set  collection instance offset from object active object, rather than 3D Cursor.
Available from the _Collections Menu_ in the _Properties Window > Object_.
