### PR TITLE
UI: expose region3d.lock_rotation in view_3d UI

### DIFF
--- a/release/scripts/startup/bl_ui/space_view3d.py
+++ b/release/scripts/startup/bl_ui/space_view3d.py
@@ -5441,7 +5441,7 @@ class VIEW3D_PT_view3d_lock(Panel):
             subcol.prop(view, "lock_cursor", text="To 3D Cursor")
 
         col.prop(view, "lock_camera", text="Camera to View")
-
+        col.prop(view, "region_3d.lock_rotation, text="Lock View Rotation") 
 
 class VIEW3D_PT_view3d_cursor(Panel):
     bl_space_type = 'VIEW_3D'


### PR DESCRIPTION
Expose functionality for users to lock 3d view rotation
I have sometimes had the need to lock the rotation of the 3d view, so I felt this could be useful to other users too.

Exact location of proposed change
class VIEW3D_PT_view3d_lock
line 5444

Thanks