### PR TITLE
minor optimization in lazy_function.cc

### DIFF
--- a/source/blender/functions/intern/lazy_function.cc
+++ b/source/blender/functions/intern/lazy_function.cc
@@ -49,17 +49,17 @@ void LazyFunction::possible_output_dependencies(const int /*output_index*/,
 
 bool LazyFunction::always_used_inputs_available(const Params &params) const
 {
-  if (allow_missing_requested_inputs_) {
-    return true;
-  }
-  for (const int i : inputs_.index_range()) {
-    const Input &fn_input = inputs_[i];
-    if (fn_input.usage == ValueUsage::Used) {
-      if (params.try_get_input_data_ptr(i) == nullptr) {
-        return false;
+  if (!allow_missing_requested_inputs_) {
+    for (const int i : inputs_.index_range()) {
+      const Input &fn_input = inputs_[i];
+      if (fn_input.usage == ValueUsage::Used) {
+        if (params.try_get_input_data_ptr(i) == nullptr) {
+          return false;
+        }
       }
     }
   }
+
   return true;
 }
 


### PR DESCRIPTION
Did minor optimization in code, rather than checking for "allow_missing_requested_inputs" is present, it will will check if "allow_missing_requested_inputs" not present, thus reducing the "return true" to one only in function "LazyFunction::always_used_inputs_available"