### PR TITLE
Cleanup: Rephrased a vague comment

### DIFF
--- a/intern/iksolver/intern/IK_QJacobianSolver.h
+++ b/intern/iksolver/intern/IK_QJacobianSolver.h
@@ -37,7 +37,7 @@ class IK_QJacobianSolver {
   // call setup once before solving, if it fails don't solve
   bool Setup(IK_QSegment *root, std::list<IK_QTask *> &tasks);
 
-  // returns true if converged, false if max number of iterations was used
+  // returns true if converged, false if failed to converge after maximum number of iterations
   bool Solve(IK_QSegment *root,
              std::list<IK_QTask *> tasks,
              const double tolerance,


### PR DESCRIPTION
In one of the header files, the comment's wording wasn't perfect for the condition to return false

This repository is only used as a mirror. Blender development happens on projects.blender.org.