### PR TITLE
add missing word 'drag' - to be grammatically correct and consistent with the other descriptions within the 'Blender Preferences' tab.

### DIFF
--- a/locale/po/ca.po
+++ b/locale/po/ca.po
@@ -90225,7 +90225,7 @@ msgid "Motion Threshold"
 msgstr "Llindar de moviment"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "[Motion Threshold]: Nombre de píxels abans que es consideri que s'ha mogut el cursor (utilitzat per a ciclitzar els elements seleccionats en clics successius)"
 
 

--- a/locale/po/es.po
+++ b/locale/po/es.po
@@ -90225,7 +90225,7 @@ msgid "Motion Threshold"
 msgstr "Umbral de movimiento"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "Cantidad de píxeles antes de que se considere que el cursor se ha movido (usado al seleccionar cíclicamente elementos con sucesivos clics)"
 
 

--- a/locale/po/fr.po
+++ b/locale/po/fr.po
@@ -90225,7 +90225,7 @@ msgid "Motion Threshold"
 msgstr "Seuil de mouvement"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "Nombre de pixels avant de considérer que le curseur s’est déplacé (utilisé pour passer d’un élément sélectionné à l’autre quand on clique plusieurs fois)"
 
 

--- a/locale/po/ja.po
+++ b/locale/po/ja.po
@@ -90336,7 +90336,7 @@ msgid "Motion Threshold"
 msgstr "移動のしきい値"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr ""
 "カーソルが移動したと見なされるのに必要なピクセル数\n"
 "（連続クリック時のアイテム選択の循環で使用）"

--- a/locale/po/ko.po
+++ b/locale/po/ko.po
@@ -61991,7 +61991,7 @@ msgid "Motion Threshold"
 msgstr "모션 임계 값"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "커서가 이동 한 것으로 간주되기 전까지의 픽셀 수 (연속 클릭시 선택한 항목을 순환시키기 위해 사용)"
 
 

--- a/locale/po/ru.po
+++ b/locale/po/ru.po
@@ -67256,7 +67256,7 @@ msgid "Motion Threshold"
 msgstr "Порог движения"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "Количество пикселей, на которое необходимо переместить указатель мыши, чтобы это зафиксировалось как движение (используется для циклического выбора элементов при последовательном нажатии)"
 
 

--- a/locale/po/sk.po
+++ b/locale/po/sk.po
@@ -90074,7 +90074,7 @@ msgid "Motion Threshold"
 msgstr "Prah pohybu"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "Počet pixelov predtým, než je kurzor považovaný za premiestnený (používa sa na cyklovanie vybratých položiek po následných kliknutiach)"
 
 

--- a/locale/po/uk.po
+++ b/locale/po/uk.po
@@ -71186,7 +71186,7 @@ msgid "Motion Threshold"
 msgstr "Поріг Руху"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "Кількість пікселів перед тим, як курсор вважається переміщеним (вживається для обходу вибраних елементів по послідовних клацках)"
 
 

--- a/locale/po/vi.po
+++ b/locale/po/vi.po
@@ -89938,7 +89938,7 @@ msgid "Motion Threshold"
 msgstr "Ngưỡng Chuyển Động"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "Số điểm ảnh phải di chuyển trước khi con trỏ được coi là đã di chuyển (sử dụng để luân chuyển những cái được chọn trong những lần bấm tiếp theo)"
 
 

--- a/locale/po/zh_HANS.po
+++ b/locale/po/zh_HANS.po
@@ -89911,7 +89911,7 @@ msgid "Motion Threshold"
 msgstr "动作阈值"
 
 
-msgid "Number of pixels to before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
+msgid "Number of pixels to drag before the cursor is considered to have moved (used for cycling selected items on successive clicks)"
 msgstr "认定光标移动所需的像素数 (用于在连续点击时切换所选项目)"
 
 

--- a/source/blender/makesrna/intern/rna_userdef.cc
+++ b/source/blender/makesrna/intern/rna_userdef.cc
@@ -6351,7 +6351,7 @@ static void rna_def_userdef_input(BlenderRNA *brna)
   RNA_def_property_ui_range(prop, 0, 10, 1, -1);
   RNA_def_property_ui_text(prop,
                            "Motion Threshold",
-                           "Number of pixels to before the cursor is considered to have moved "
+                           "Number of pixels to drag before the cursor is considered to have moved "
                            "(used for cycling selected items on successive clicks)");
 
   /* tablet pressure curve */


### PR DESCRIPTION
This PR is to correct a minor grammatical error.  In the 'Blender Preferences' section with the 'Edit' section, the word "drag" is missing for the 'Motion Threshold' description within the 'Mouse' section.
