### PR TITLE
Cycles: Fixed standalone build failed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2585,6 +2585,7 @@ if(WITH_BLENDER)
   # internal and external library information first, for test linking
   add_subdirectory(source)
 elseif(WITH_CYCLES_STANDALONE OR WITH_CYCLES_HYDRA_RENDER_DELEGATE)
+  add_subdirectory(intern/atomic)
   add_subdirectory(intern/guardedalloc)
   add_subdirectory(intern/libc_compat)
   add_subdirectory(intern/sky)

--- a/intern/cycles/app/opengl/shader.cpp
+++ b/intern/cycles/app/opengl/shader.cpp
@@ -51,7 +51,7 @@ static void shader_print_errors(const char *task, const char *log, const char *c
   LOG(ERROR) << "Shader: " << task << " error:";
   LOG(ERROR) << "===== shader string ====";
 
-  stringstream stream(code);
+  std::stringstream stream(code);
   string partial;
 
   int line = 1;


### PR DESCRIPTION
in main branch, make cycles will failed with output "can't find bf::intern::atomic library", this patch add lookup path for intern/atomic, and fixed an typo in cycles/app/shader.cpp


To get started with contributing code, please see:
https://developer.blender.org/docs/handbook/contributing/
