### PR TITLE
Add logging level control for gltf exports

### DIFF
--- a/scripts/addons_core/io_scene_gltf2/__init__.py
+++ b/scripts/addons_core/io_scene_gltf2/__init__.py
@@ -162,6 +162,18 @@ def is_draco_available():
 
     return is_draco_available.draco_exists
 
+def set_debug_log():
+    import logging
+    if bpy.app.debug_value == 0:      # Default values => Display all messages except debug ones
+        return logging.INFO
+    elif bpy.app.debug_value == 1:
+        return logging.WARNING
+    elif bpy.app.debug_value == 2:
+        return logging.ERROR
+    elif bpy.app.debug_value == 3:
+        return logging.CRITICAL
+    elif bpy.app.debug_value == 4:
+        return logging.DEBUG
 
 class ConvertGLTF2_Base:
     """Base class containing options that should be exposed during both import and export."""
@@ -1050,7 +1062,7 @@ class ExportGLTF2_Base(ConvertGLTF2_Base):
         # All custom export settings are stored in this container.
         export_settings = {}
 
-        export_settings['loglevel'] = logging.INFO
+        export_settings['loglevel'] = set_debug_log()
 
         export_settings['exported_images'] = {}
         export_settings['exported_texture_nodes'] = []
@@ -1863,7 +1875,7 @@ class ImportGLTF2(Operator, ConvertGLTF2_Base, ImportHelper):
     def import_gltf2(self, context):
         import os
 
-        self.set_debug_log()
+        self.loglevel = set_debug_log()
         import_settings = self.as_keywords()
 
         user_extensions = []
@@ -1922,20 +1934,6 @@ class ImportGLTF2(Operator, ConvertGLTF2_Base, ImportHelper):
             self.report({'ERROR'}, e.args[0])
             return {'CANCELLED'}
 
-    def set_debug_log(self):
-        import logging
-        if bpy.app.debug_value == 0:      # Default values => Display all messages except debug ones
-            self.loglevel = logging.INFO
-        elif bpy.app.debug_value == 1:
-            self.loglevel = logging.WARNING
-        elif bpy.app.debug_value == 2:
-            self.loglevel = logging.ERROR
-        elif bpy.app.debug_value == 3:
-            self.loglevel = logging.CRITICAL
-        elif bpy.app.debug_value == 4:
-            self.loglevel = logging.DEBUG
-
-
 def import_bone_panel(layout, operator):
     header, body = layout.panel("GLTF_import_bone", default_closed=False)
     header.label(text="Bones")
@@ -1944,7 +1942,6 @@ def import_bone_panel(layout, operator):
         if operator.bone_heuristic == 'BLENDER':
             body.prop(operator, 'disable_bone_shape')
             body.prop(operator, 'bone_shape_scale_factor')
-
 
 def import_panel_user_extension(context, layout):
     for draw in importer_extension_layout_draw.values():


### PR DESCRIPTION
I have made changes to `ExportGLTF2_Base` in:
`blender/scripts/addons_core/io_scene_gltf2/__init__.py` 

changes support modifying the log level instead of using the hardcoded `INFO` value  [here](https://github.com/blender/blender/blob/0d70481d15da54560f70f8de8d26c973585aa3e7/scripts/addons_core/io_scene_gltf2/__init__.py#L1054) which produces way to much output when exporting.

`ImportGLTF2` already has a pattern for this [here](https://github.com/blender/blender/blob/0d70481d15da54560f70f8de8d26c973585aa3e7/scripts/addons_core/io_scene_gltf2/__init__.py#L1866) so I created a global `set_debug_level` function they can both use in the same manner.

The user can now set the log level before exporting by setting `bpy.app.debug_value` like:

```python
bpy.app.debug_value = 2
bpy.ops.export_scene.gltf(...)
```



