### PR TITLE
UI: Caret position increment interface values

### DIFF
--- a/source/blender/editors/interface/interface_handlers.cc
+++ b/source/blender/editors/interface/interface_handlers.cc
@@ -3273,13 +3273,22 @@ static void ui_numedit_but_inc(uiBut *but, uiTextEdit &text_edit, const int mod 
 
     std::string str_num_incremented = std::to_string(result);
 
-    str_num_incremented = str_num_incremented.substr(0, str_num.length() - is_positive);
+    if (dot_pos == 0) {
+      str_num_incremented.erase(str_num_incremented.find_last_not_of('0') + 1, std::string::npos);
+      str_num_incremented.erase(str_num_incremented.find_last_not_of('.') + 1, std::string::npos);
+    }
+    else {
+      str_num_incremented = str_num_incremented.substr(0, str_num.length() - is_positive);
+    }
 
     std::string lstrip = str_edit.substr(0, num_str_start);
     std::string rstrip = str_edit.substr(but->pos + 1, str_edit.length() - but->pos);
 
     ui_textedit_string_set(but, text_edit, (lstrip + str_num_incremented + rstrip).c_str());
-    but->pos -= is_positive;
+
+    if (str_num_incremented.size() != str_num.size()) {
+      but->pos += int(str_num_incremented.size() > str_num.size()) * 2 - 1;
+    }
   }
 }
 

--- a/source/blender/editors/interface/interface_handlers.cc
+++ b/source/blender/editors/interface/interface_handlers.cc
@@ -3235,7 +3235,7 @@ static void ui_numedit_but_inc(uiBut *but, uiTextEdit &text_edit, const int mod 
     for (int i = but->pos; i >= 0; i--) {
       char c = text_edit.edit_string[i];
       if (c == '.') {
-        if (dot_pos == -1) {
+        if (dot_pos == 0) {
           dot_pos = but->pos - i;
         }
         else {
@@ -3261,8 +3261,6 @@ static void ui_numedit_but_inc(uiBut *but, uiTextEdit &text_edit, const int mod 
 
     double prev_result = std::stod(str_num);
     double result = prev_result + fadd * mod;
-
-    std::cout << result << std::endl;
 
     int is_positive = 0;
 


### PR DESCRIPTION
UI: Change a number's increment on any interface number value via the caret position

just select a part of your value (this can be any number value) and hit CTRL + "NUMPAD +" or CTRL + "NUMPAD -" to increment or decrement the value after the cursor. The incremented result will update the editor accordingly to view the changes in real time.

The user will have to move their text cursor **before** the number they want to increment then hit the shortcut to increment and decrement it.

This is useful for finer changes within a value (particularly useful for compositor/shader value changes) that can't be reached via the precision value changing (using shift hold and dragging a value)

Right Click Select Proposal:
https://blender.community/c/rightclickselect/q6bbbc/

Video Proposal:
https://www.youtube.com/watch?v=Ps8RaHhbVSg
(Good to note, this video demonstrates this feature with the wrong keyboard shortcut, it has been updated to CTRL + "NUMPAD +" or CTRL + "NUMPAD -" instead of CTRL + "[" or CTRL + "]")

Demo:
![blender_Av1wdBugGC](https://github.com/user-attachments/assets/38b97d9e-f4b8-41b8-90f8-3729ec686cc9)


