### PR TITLE
Adding Building Blender link

### DIFF
--- a/extern/audaspace/bindings/doc/index.rst
+++ b/extern/audaspace/bindings/doc/index.rst
@@ -3,8 +3,12 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+
 Welcome to audaspace's documentation!
 =====================================
+
+For detailed and up-to-date build instructions, please refer to the official Blender Wiki:
+https://wiki.blender.org/wiki/Building_Blender
 
 .. automodule:: aud
    :no-members:


### PR DESCRIPTION
Adding Building Blender link to the file for better organization.

This repository is only used as a mirror. Blender development happens on projects.blender.org.

To get started with contributing code, please see:
https://developer.blender.org/docs/handbook/contributing/
