### PR TITLE
eliminate icx build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,8 @@ include(build_files/cmake/macros.cmake)
 blender_project_hack_pre()
 
 project(Blender)
+string(APPEND CMAKE_C_FLAGS " /arch:SSE4.2 -Wno-error=unused-command-line-argument -Wno-char-subscripts -Wno-unused-function")
+string(APPEND CMAKE_CXX_FLAGS " /arch:SSE4.2 -Wno-error=unused-command-line-argument -Wno-char-subscripts -Wno-unused-function")
 
 blender_project_hack_post()
 

--- a/source/blender/blenlib/CMakeLists.txt
+++ b/source/blender/blenlib/CMakeLists.txt
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2006 Blender Authors
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
+string(APPEND CMAKE_C_FLAGS " /fp:precise")
+string(APPEND CMAKE_CXX_FLAGS " /fp:precise")
 
 if(HAVE_EXECINFO_H)
   add_definitions(-DHAVE_EXECINFO_H)


### PR DESCRIPTION
Cmake changes to make the build with icx happen

commands:
source intel oneapi setvars.bat
cmake -DCMAKE_C_COMPILER=icx-cl -DCMAKE_CXX_COMPILER=icx-cl -DCMAKE_RC_COMPILER=rc.exe -D CMAKE_BUILD_TYPE=Release -G Ninja ..\blender
cmake --build . --config=Release

